### PR TITLE
Moving Google Map Type Control to upper left corner

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -233,7 +233,12 @@
         var mapOptions = {
           zoom: 11,
           center: new google.maps.LatLng(40.682,-74.03),
-          mapTypeId: google.maps.MapTypeId.ROADMAP
+          //mapTypeId: google.maps.MapTypeId.ROADMAP
+          mapTypeControl: true,
+          mapTypeControlOptions: {
+              style: google.maps.MapTypeControlStyle.HORIZONTAL_BAR,
+              position: google.maps.ControlPosition.TOP_LEFT
+          },
         };
         map = new google.maps.Map(document.getElementById('map'),  mapOptions);
         var styles = [


### PR DESCRIPTION
We can also move the control to the bottom, but then it's hidden by the footer right now. Marc, does this work for now?

You can see the result here: http://schmiani.github.io/NYCdaycare/
