### PR TITLE
Ahhhh typo!!!!

### DIFF
--- a/_layouts/gumby-ui.html
+++ b/_layouts/gumby-ui.html
@@ -127,7 +127,7 @@
 <div data-target="the-story" class="about-box inview txt">
     <h1 class="inview txt" gumby-classname="onscreen" gumby-offset="50">The Story</h1>
     <p class="inview link" gumby-classname="onscreen" gumby-offset="50">
-        From some background on how the project was started please read the following HuffPostCode article:</p>
+        For background on how the project was started please read the following HuffPostCode article:</p>
         <p class="inview link" gumby-classname="onscreen"><a href="http://www.huffingtonpost.com/marc-shifflett/when-open-data-meets-app_b_5504232.html" target="_blank">Scraping Day Care Data in the Naked City</a></p>
 </div>
 <p style="text-align: center;"><a href="#top" gumby-update gumby-goto="[data-target='top']"><i class="icon-home"></i></a></p>


### PR DESCRIPTION
http://mashcode.github.io/NYCdaycare/dev/mobile/
TODO

Why the top navbar is not fixed on mobile?
Why the top navbar links don't target precisely on desktop?
Hookup mobile search
Fixed - Mobile filter btn toggles on but not off
