### PR TITLE
Put date last updated in footer

### DIFF
--- a/_layouts/nyccdb.html
+++ b/_layouts/nyccdb.html
@@ -149,8 +149,9 @@
 
 <div id="footer" class="row">
     <ul>
-    <li class="two columns" style="vertical-align:middle;"><a href="#top" gumby-update gumby-goto="[data-target='top']">&copy; NYC Day Care Map</a></li> 
-    <li class="ten columns" style="text-align:right;vertical-align:top;">Check us out on <a href="https://github.com/childcaremap/NYCdaycare" target="new window"><i class="icon-github"></i></a></li>
+    <li class="two columns" style="vertical-align:middle;"><a href="#top" gumby-update gumby-goto="[data-target='top']">&copy; NYC Day Care Map</a></li>
+    <li class="eight columns" style="text-align:right;vertical-align:top;">Last updated: July 14th 2014</li>
+    <li class="two columns" style="text-align:right;vertical-align:top;">Check us out on <a href="https://github.com/childcaremap/NYCdaycare" target="new window"><i class="icon-github"></i></a></li>
     <ul>
 </div>
 

--- a/_layouts/nyccdb.html
+++ b/_layouts/nyccdb.html
@@ -151,7 +151,7 @@
     <ul>
     <li class="two columns" style="vertical-align:middle;"><a href="#top" gumby-update gumby-goto="[data-target='top']">&copy; NYC Day Care Map</a></li>
     <li class="eight columns" style="text-align:right;vertical-align:top;">Updated 7-14-14</li>
-    <li class="two columns" style="text-align:right;vertical-align:top;">Check us out on <a href="https://github.com/childcaremap/NYCdaycare" target="new window"><i class="icon-github"></i></a></li>
+    <li class="two columns" style="text-align:right;vertical-align:top;">Check us out on<a href="https://github.com/childcaremap/NYCdaycare" target="new window"><i class="icon-github"></i></a></li>
     <ul>
 </div>
 

--- a/_layouts/nyccdb.html
+++ b/_layouts/nyccdb.html
@@ -150,7 +150,7 @@
 <div id="footer" class="row">
     <ul>
     <li class="two columns" style="vertical-align:middle;"><a href="#top" gumby-update gumby-goto="[data-target='top']">&copy; NYC Day Care Map</a></li>
-    <li class="eight columns" style="text-align:right;vertical-align:top;">Last updated: July 14th 2014</li>
+    <li class="eight columns" style="text-align:right;vertical-align:top;">Updated 7-14-14</li>
     <li class="two columns" style="text-align:right;vertical-align:top;">Check us out on <a href="https://github.com/childcaremap/NYCdaycare" target="new window"><i class="icon-github"></i></a></li>
     <ul>
 </div>


### PR DESCRIPTION
Space is tight on the mobile phone in portrait. Maybe move the GitHub link to the About section? I like the date updated in the footer, I think it should be very clear and transparent when we retrieved the data.
