### PR TITLE
Fixing bug in medicine checkbox

### DIFF
--- a/_layouts/nyccdb.html
+++ b/_layouts/nyccdb.html
@@ -106,7 +106,7 @@
     </div>
     <div id="medicine_selector" class="cartodb-infobox">
         <ul>
-        <li data=" "><input class="data-swap" data="all" type="checkbox"> &nbsp;Certified To Give Medicine?</li>
+        <li data="all"><input class="data-swap" data="all" type="checkbox"> &nbsp;Certified To Give Medicine?</li>
         <!--li data="all" style="background-color:#eeeeee;">Certified To Give Medicine?</li>
         <li class="data-swap medium" data="all" data-label-on="Hide" data-label-off="Show" style="text-align:center;border:1px solid #808080;padding:4px 10px;margin:10px 10px;">Show</li-->
         


### PR DESCRIPTION
There was a bug so that the filtering didn't work properly before the checkbox was used at least once. Just had to change the default data value to "all", now it's working!
